### PR TITLE
Specify region in the S3 storage definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ import xarray as xr
 storage = icechunk.s3_storage(
     bucket='nasa-waterinsight',
     prefix=f"virtual-zarr-store/NLDAS-3-icechunk",
+    region="us-west-2",
     anonymous=True,
 )
 


### PR DESCRIPTION
This change is necessary for loading chunks to work.